### PR TITLE
feat(android, ios, ontableofcontents): update onTableOfContents to re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ DRM is not supported at this time. However, there is a clear path to [support it
 | `settings` | [`Partial<Settings>`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Settings.ts)  | :white_check_mark: | An object that allows you to control various aspects of the reader's UI (epub only) |
 | `style`    | `ViewStyle`          | :white_check_mark: | A traditional style object. |
 | `onLocationChange` | `(locator: Locator) => void` | :white_check_mark: | A callback that fires whenever the location is changed (e.g. the user transitions to a new page)|
-| `onTableOfContents` | `(toc: Link[] \| null) => void` | :white_check_mark: | A callback that fires once the file is parsed and emits the table of contents embedded in the file. Returns `null` or an empty `[]` if no TOC exists. See the [`Link`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Link.ts) interface for more info. |
+| `onTableOfContents` | `(toc: Locator[] \| null) => void` | :white_check_mark: | A callback that fires once the file is parsed and emits the table of contents embedded in the file. Returns `null` or an empty `[]` if no TOC exists. See the [`Locator`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Locator.ts) interface for more info. |
 
 ## Contributing
 

--- a/android/src/main/java/com/reactnativereadium/reader/BaseReaderFragment.kt
+++ b/android/src/main/java/com/reactnativereadium/reader/BaseReaderFragment.kt
@@ -10,7 +10,6 @@ import org.readium.r2.navigator.*
 import org.readium.r2.shared.publication.Locator
 import com.reactnativereadium.utils.EventChannel
 import kotlinx.coroutines.channels.Channel
-import org.readium.r2.shared.publication.Link
 
 /*
  * Base reader fragment class
@@ -37,7 +36,11 @@ abstract class BaseReaderFragment : Fragment() {
 
     val viewScope = viewLifecycleOwner.lifecycleScope
 
-    channel.send(ReaderViewModel.Event.TableOfContentsLoaded(model.publication.tableOfContents))
+    val tocLocators: List<Locator> = model.publication.tableOfContents.mapNotNull {
+      model.publication.locatorFromLink(it)
+    }
+
+    channel.send(ReaderViewModel.Event.TableOfContentsLoaded(tocLocators))
     navigator.currentLocator
       .onEach { channel.send(ReaderViewModel.Event.LocatorUpdate(it)) }
       .launchIn(viewScope)

--- a/android/src/main/java/com/reactnativereadium/reader/ReaderViewModel.kt
+++ b/android/src/main/java/com/reactnativereadium/reader/ReaderViewModel.kt
@@ -20,7 +20,6 @@ import org.readium.r2.shared.publication.services.search.SearchIterator
 import org.readium.r2.shared.publication.services.search.SearchTry
 import org.readium.r2.shared.Search
 import org.readium.r2.shared.UserException
-import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.util.Try
 
 @OptIn(Search::class, ExperimentalDecorator::class)
@@ -112,7 +111,7 @@ class ReaderViewModel(
         object StartNewSearch : Event()
         class Failure(val error: UserException) : Event()
         class LocatorUpdate(val locator: Locator) : Event()
-        class TableOfContentsLoaded(val toc: List<Link>) : Event()
+        class TableOfContentsLoaded(val toc: List<Locator>) : Event()
     }
 
     sealed class FeedbackEvent {

--- a/example/src/Reader.tsx
+++ b/example/src/Reader.tsx
@@ -5,7 +5,7 @@ import {
   ReadiumView,
   Settings,
 } from 'react-native-readium';
-import type { Link, Locator, File } from 'react-native-readium';
+import type { Locator, File } from 'react-native-readium';
 
 import {
   EPUB_URL,
@@ -17,7 +17,7 @@ import { TableOfContents } from './TableOfContents';
 import { Settings as ReaderSettings } from './Settings';
 
 const Reader: React.FC = () => {
-  const [toc, setToc] = useState<Link[] | null>([]);
+  const [toc, setToc] = useState<Locator[] | null>([]);
   const [file, setFile] = useState<File>();
   const [location, setLocation] = useState<Locator>();
   const [settings, setSettings] = useState<Partial<Settings>>(DEFAULT_SETTINGS);
@@ -59,12 +59,7 @@ const Reader: React.FC = () => {
         }}>
           <TableOfContents
             items={toc}
-            onPress={(link) => {
-              setLocation({
-                href: link.href,
-                type: 'application/xhtml+xml',
-              });
-            }}
+            onPress={(loc) => setLocation(loc)}
           />
           <ReaderSettings
             settings={settings}

--- a/example/src/TableOfContents.tsx
+++ b/example/src/TableOfContents.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { Text, ScrollView } from 'react-native';
 import { ListItem, Overlay, Icon } from '@rneui/themed';
-import type { Link } from 'react-native-readium';
+import type { Locator } from 'react-native-readium';
 
 export interface TableOfContentsProps {
-  items?: Link[] | null;
-  onPress?: (link: Link) => void;
+  items?: Locator[] | null;
+  onPress?: (locator: Locator) => void;
 }
 
 export const TableOfContents: React.FC<TableOfContentsProps> = ({
@@ -36,7 +36,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
           <Text>Table of Contents</Text>
           {items.map((item, idx) => (
             <ListItem
-              key={item.href}
+              key={idx}
               onPress={() => {
                 if (onPress) {
                   onPress(item);

--- a/ios/ReadiumView.swift
+++ b/ios/ReadiumView.swift
@@ -163,8 +163,11 @@ class ReadiumView : UIView, Loggable {
     rootView.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
 
     self.onTableOfContents?([
-      "toc": vc.publication.tableOfContents.map({ link in
-        return link.json
+      "toc": vc.publication.tableOfContents.compactMap({ (link) -> [String: Any]? in
+        guard let locator = vc.publication.locate(link) else {
+            return nil
+        }
+        return locator.json
       })
     ])
   }

--- a/src/components/BaseReadiumView.tsx
+++ b/src/components/BaseReadiumView.tsx
@@ -4,7 +4,7 @@ import {
   ViewStyle,
 } from 'react-native';
 
-import type { Settings, Link, Locator, File, } from '../interfaces';
+import type { Settings, Locator, File, } from '../interfaces';
 import { COMPONENT_NAME, LINKING_ERROR } from '../utils';
 
 export type BaseReadiumViewProps = {
@@ -13,7 +13,7 @@ export type BaseReadiumViewProps = {
   settings?: Partial<Settings>;
   style?: ViewStyle;
   onLocationChange?: (locator: Locator) => void;
-  onTableOfContents?: (toc: Link[] | null) => void;
+  onTableOfContents?: (toc: Locator[] | null) => void;
   ref?: any;
   height?: number;
   width?: number;


### PR DESCRIPTION
…turn Locator[] for consistency

Links and Locators are not the same and need to be handled differently. To avoid complexity, the library has been update to only deal with Locators and map all Links it returns to Locators.

BREAKING CHANGE: onTableOfContents now returns a `Locator[]` instead of a `Link[]`. Update your `onTableOfContents` callbacks from `(toc: Link[]) => {...}` to `(toc: Locator[]) => {...}`.

https://github.com/5-stones/react-native-readium/issues/11