### PR TITLE
fix(android, ios): allow location and initialLocation to be either Li…

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ DRM is not supported at this time. However, there is a clear path to [support it
 | Name | Type | Optional | Description |
 |------|------|----------|-------------|
 | `file`     | [`File`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/File.ts)               | :x:                | A file object containing the path to the eBook file on disk. |
-| `location` | [`Locator`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Locator.ts)            | :white_check_mark: | A locator prop that allows you to externally control the location of the reader (e.g. Chapters or Bookmarks)|
+| `location` | [`Locator`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Locator.ts) | [`Link`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Link.ts)           | :white_check_mark: | A locator prop that allows you to externally control the location of the reader (e.g. Chapters or Bookmarks)|
 | `settings` | [`Partial<Settings>`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Settings.ts)  | :white_check_mark: | An object that allows you to control various aspects of the reader's UI (epub only) |
 | `style`    | `ViewStyle`          | :white_check_mark: | A traditional style object. |
 | `onLocationChange` | `(locator: Locator) => void` | :white_check_mark: | A callback that fires whenever the location is changed (e.g. the user transitions to a new page)|

--- a/android/src/main/java/com/reactnativereadium/ReadiumView.kt
+++ b/android/src/main/java/com/reactnativereadium/ReadiumView.kt
@@ -11,8 +11,8 @@ import com.reactnativereadium.reader.EpubReaderFragment
 import com.reactnativereadium.reader.ReaderViewModel
 import com.reactnativereadium.utils.Dimensions
 import com.reactnativereadium.utils.File
+import com.reactnativereadium.utils.LinkOrLocator
 import org.readium.r2.shared.extensions.toMap
-import org.readium.r2.shared.publication.Locator
 
 class ReadiumView(
   val reactContext: ThemedReactContext
@@ -22,11 +22,11 @@ class ReadiumView(
   var fragment: BaseReaderFragment? = null
   var isViewInitialized: Boolean = false
 
-  fun updateLocation(locator: Locator) : Boolean {
+  fun updateLocation(location: LinkOrLocator) : Boolean {
     if (fragment == null) {
       return false
     } else {
-      return this.fragment!!.go(locator, true)
+      return this.fragment!!.go(location, true)
     }
   }
 

--- a/android/src/main/java/com/reactnativereadium/reader/BaseReaderFragment.kt
+++ b/android/src/main/java/com/reactnativereadium/reader/BaseReaderFragment.kt
@@ -4,13 +4,13 @@ import android.os.Bundle
 import android.view.*
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import com.reactnativereadium.utils.LinkOrLocator
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.readium.r2.navigator.*
 import org.readium.r2.shared.publication.Locator
 import com.reactnativereadium.utils.EventChannel
 import kotlinx.coroutines.channels.Channel
-import org.readium.r2.shared.publication.Link
 
 /*
  * Base reader fragment class
@@ -49,7 +49,21 @@ abstract class BaseReaderFragment : Fragment() {
     requireActivity().invalidateOptionsMenu()
   }
 
-  fun go(locator: Locator, animated: Boolean): Boolean {
+  fun go(location: LinkOrLocator, animated: Boolean): Boolean {
+    var locator: Locator? = null
+    when (location) {
+      is LinkOrLocator.Link -> {
+        locator = navigator.publication.locatorFromLink(location.link)
+      }
+      is LinkOrLocator.Locator -> {
+        locator = location.locator
+      }
+    }
+
+    if (locator == null) {
+      return false
+    }
+
     // don't attempt to navigate if we're already there
     val currentLocator = navigator.currentLocator.value
     if (locator.hashCode() == currentLocator.hashCode()) {

--- a/android/src/main/java/com/reactnativereadium/utils/File.kt
+++ b/android/src/main/java/com/reactnativereadium/utils/File.kt
@@ -1,8 +1,6 @@
 package com.reactnativereadium.utils
 
-import org.readium.r2.shared.publication.Locator
-
 class File(
   var path: String,
-  var initialLocation: Locator?
+  var initialLocation: LinkOrLocator?
 ) {}

--- a/android/src/main/java/com/reactnativereadium/utils/LinkOrLocator.kt
+++ b/android/src/main/java/com/reactnativereadium/utils/LinkOrLocator.kt
@@ -1,0 +1,9 @@
+package com.reactnativereadium.utils
+
+import org.readium.r2.shared.publication.Link as BaseLink
+import org.readium.r2.shared.publication.Locator as BaseLocator
+
+sealed class LinkOrLocator {
+  class Link(val link: BaseLink): LinkOrLocator()
+  class Locator(val locator: BaseLocator): LinkOrLocator()
+}

--- a/example/src/Reader.tsx
+++ b/example/src/Reader.tsx
@@ -19,7 +19,7 @@ import { Settings as ReaderSettings } from './Settings';
 const Reader: React.FC = () => {
   const [toc, setToc] = useState<Link[] | null>([]);
   const [file, setFile] = useState<File>();
-  const [location, setLocation] = useState<Locator>();
+  const [location, setLocation] = useState<Locator | Link>();
   const [settings, setSettings] = useState<Partial<Settings>>(DEFAULT_SETTINGS);
 
   useEffect(() => {
@@ -59,12 +59,7 @@ const Reader: React.FC = () => {
         }}>
           <TableOfContents
             items={toc}
-            onPress={(link) => {
-              setLocation({
-                href: link.href,
-                type: 'application/xhtml+xml',
-              });
-            }}
+            onPress={(loc) => setLocation(loc)}
           />
           <ReaderSettings
             settings={settings}

--- a/example/src/TableOfContents.tsx
+++ b/example/src/TableOfContents.tsx
@@ -5,7 +5,7 @@ import type { Link } from 'react-native-readium';
 
 export interface TableOfContentsProps {
   items?: Link[] | null;
-  onPress?: (link: Link) => void;
+  onPress?: (locator: Link) => void;
 }
 
 export const TableOfContents: React.FC<TableOfContentsProps> = ({
@@ -36,7 +36,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
           <Text>Table of Contents</Text>
           {items.map((item, idx) => (
             <ListItem
-              key={item.href}
+              key={idx}
               onPress={() => {
                 if (onPress) {
                   onPress(item);

--- a/ios/ReadiumView.swift
+++ b/ios/ReadiumView.swift
@@ -17,12 +17,9 @@ class ReadiumView : UIView, Loggable {
 
   @objc var file: NSDictionary? = nil {
     didSet {
-      if let initialLocation = file?["initialLocation"] as? NSDictionary {
-        location = initialLocation
-      }
-
+      let initialLocation = file?["initialLocation"] as? NSDictionary
       if let url = file?["url"] as? String {
-        self.loadBook(url: url)
+        self.loadBook(url: url, location: initialLocation)
       }
     }
   }
@@ -39,27 +36,26 @@ class ReadiumView : UIView, Loggable {
   @objc var onLocationChange: RCTDirectEventBlock?
   @objc var onTableOfContents: RCTDirectEventBlock?
 
-  func loadBook(url: String) {
+  func loadBook(
+    url: String,
+    location: NSDictionary?
+  ) {
     guard let rootViewController = UIApplication.shared.delegate?.window??.rootViewController else { return }
-    let locator: Locator? = self.getLocator()
 
     self.readerService.buildViewController(
       url: url,
       bookId: url,
-      locator: locator,
+      location: location,
       sender: rootViewController,
       completion: { vc in
         self.addViewControllerAsSubview(vc)
+        self.location = location
       }
     )
   }
 
   func getLocator() -> Locator? {
-    if (location != nil) {
-      return try? Locator(json: location)
-    } else {
-      return nil
-    }
+    return ReaderService.locatorFromLocation(location, readerViewController?.publication)
   }
 
   func updateLocation() {

--- a/src/components/BaseReadiumView.tsx
+++ b/src/components/BaseReadiumView.tsx
@@ -9,7 +9,7 @@ import { COMPONENT_NAME, LINKING_ERROR } from '../utils';
 
 export type BaseReadiumViewProps = {
   file: File;
-  location?: Locator;
+  location?: Locator | Link;
   settings?: Partial<Settings>;
   style?: ViewStyle;
   onLocationChange?: (locator: Locator) => void;

--- a/src/interfaces/File.ts
+++ b/src/interfaces/File.ts
@@ -1,3 +1,4 @@
+import type { Link } from './Link';
 import type { Locator } from './Locator';
 
 
@@ -10,5 +11,5 @@ export interface File {
   /**
    * An optional location that the eBook will be opened at.
    */
-  initialLocation?: Locator;
+  initialLocation?: Locator | Link;
 }


### PR DESCRIPTION
…nk or Locator objects

Links and Locators are not the same and need to be handled differently. Regardless of which object is passed to `location`, convert it to the proper Locator and navigate to it.

https://github.com/5-stones/react-native-readium/issues/11