### PR TITLE
fix: fix ref cannot be passed to functional components

### DIFF
--- a/example/src/components/Reader.tsx
+++ b/example/src/components/Reader.tsx
@@ -4,7 +4,7 @@ import {
   ReadiumView,
   Settings,
 } from 'react-native-readium';
-import type { Link, Locator, File } from 'react-native-readium';
+import type { Link, Locator, File, BaseReadiumViewRef } from 'react-native-readium';
 
 import RNFS from '../utils/RNFS';
 import {
@@ -22,7 +22,7 @@ export const Reader: React.FC = () => {
   const [file, setFile] = useState<File>();
   const [location, setLocation] = useState<Locator | Link>();
   const [settings, setSettings] = useState<Partial<Settings>>(DEFAULT_SETTINGS);
-  const ref = useRef<any>();
+  const ref = useRef<BaseReadiumViewRef>(null);
 
   useEffect(() => {
     async function run() {

--- a/src/components/ReadiumView.tsx
+++ b/src/components/ReadiumView.tsx
@@ -1,26 +1,24 @@
-import React, { useCallback, useState, useRef, useEffect } from 'react';
+import React, { useCallback, useState, useEffect, forwardRef } from 'react';
 import { View, Platform, findNodeHandle, StyleSheet } from 'react-native';
-
-import type { BaseReadiumViewProps, Dimensions } from '../interfaces';
+import type { BaseReadiumViewProps, BaseReadiumViewRef, Dimensions } from '../interfaces';
 import { Settings } from '../interfaces';
 import { createFragment, getWidthOrHeightValue as dimension } from '../utils';
 import { BaseReadiumView } from './BaseReadiumView';
 
 export type ReadiumProps = BaseReadiumViewProps;
 
-export const ReadiumView: React.FC<ReadiumProps> = ({
+export const ReadiumView = forwardRef<BaseReadiumViewRef, ReadiumProps>(({
   onLocationChange: wrappedOnLocationChange,
   onTableOfContents: wrappedOnTableOfContents,
   settings: unmappedSettings,
   ...props
-}) => {
-  const ref = useRef(null);
+}, ref) => {
   const [{ height, width }, setDimensions] = useState<Dimensions>({
     width: 0,
     height: 0,
   });
   // set the view dimensions on layout
-  const onLayout = useCallback(({ nativeEvent: { layout: { width, height } }}: any) => {
+  const onLayout = useCallback(({ nativeEvent: { layout: { width, height } } }: any) => {
     setDimensions({
       width: dimension(width),
       height: dimension(height),
@@ -63,7 +61,7 @@ export const ReadiumView: React.FC<ReadiumProps> = ({
       />
     </View>
   );
-};
+});
 
 const styles = StyleSheet.create({
   container: { width: '100%', height: '100%' },

--- a/src/interfaces/BaseReadiumViewProps.ts
+++ b/src/interfaces/BaseReadiumViewProps.ts
@@ -16,3 +16,8 @@ export type BaseReadiumViewProps = {
   height?: number;
   width?: number;
 };
+
+export type BaseReadiumViewRef = {
+  nextPage: () => void;
+  prevPage: () => void;
+};


### PR DESCRIPTION
ReadiumView component is not wrapped with forwardRef which causes React to error out that ref cannot be passed to functional components.

This PR fixes that.