### PR TITLE
fix(web): Handle location not defined in reading order

### DIFF
--- a/web/hooks/useReaderRef.ts
+++ b/web/hooks/useReaderRef.ts
@@ -24,6 +24,9 @@ export const useReaderRef = ({
         const newLocationIndex = readingOrder.current.findIndex(
           (entry) => entry.href === newLocation.href
         );
+        if (newLocationIndex < 0 || !readingOrder.current[newLocationIndex]) {
+          return;
+        }
         const readingOrderCount = readingOrder.current.length;
         const chapterTotalProgression =
           readingOrder.current[newLocationIndex].locations?.totalProgression ||


### PR DESCRIPTION
Fix the situation that could arise if readingOrder.current[newLocationIndex] is undefined.