### PR TITLE
fix(android): remove tap toggles ui visibility

### DIFF
--- a/android/src/main/java/com/reactnativereadium/reader/EpubReaderFragment.kt
+++ b/android/src/main/java/com/reactnativereadium/reader/EpubReaderFragment.kt
@@ -176,7 +176,6 @@ class EpubReaderFragment : VisualReaderFragment(), EpubNavigatorFragment.Listene
     }
 
     override fun onTap(point: PointF): Boolean {
-        requireActivity().toggleSystemUi()
         return true
     }
 


### PR DESCRIPTION
Remove the feature to tap in a neutral spot to remove the system ui since it is not intuitive and tends to unintentionally cause text re-flows.