### PR TITLE
Improve detection of Links when changing navigator location

### DIFF
--- a/android/src/main/java/com/reactnativereadium/ReadiumViewManager.kt
+++ b/android/src/main/java/com/reactnativereadium/ReadiumViewManager.kt
@@ -84,11 +84,14 @@ class ReadiumViewManager(
   fun locationToLinkOrLocator(location: ReadableMap): LinkOrLocator? {
     val json = JSONObject(location.toHashMap() as HashMap<*, *>)
     val hasLocations = json.has("locations")
+    val hasType = json.has("type") && !json.getString("type").isEmpty()
     val hasChildren = json.has("children")
     val hasHashHref = (json.get("href") as String).contains("#")
+    val hasTemplated = json.has("templated")
+
     var linkOrLocator: LinkOrLocator? = null
 
-    if ((hasChildren || hasHashHref) && !hasLocations) {
+    if ((!hasType || hasChildren || hasHashHref || hasTemplated) && !hasLocations) {
       val link = Link.fromJSON(json)
       if (link != null) {
         linkOrLocator = LinkOrLocator.Link(link)

--- a/ios/Reader/ReaderService.swift
+++ b/ios/Reader/ReaderService.swift
@@ -29,11 +29,13 @@ final class ReaderService: Loggable {
     }
 
     let hasLocations = location?["locations"] != nil
+    let hasType = !((location?["type"] as! String).isEmpty)
     let hasChildren = location?["children"] != nil
     let hasHashHref = (location!["href"] as! String).contains("#")
+    let hasTemplated = location?["templated"] != nil
 
     // check that we're not dealing with a Link
-    if ((hasChildren || hasHashHref) && !hasLocations) {
+    if ((!hasType || hasChildren || hasHashHref || hasTemplated) && !hasLocations) {
       guard let publication = publication else {
         return nil
       }


### PR DESCRIPTION
Resolves #81

If we take a closer look at the differences between the [Link](https://readium.org/webpub-manifest/schema/link.schema.json) and [Locator](https://github.com/readium/architecture/blob/master/schema/locator.schema.json) we see that:

- Locators have required fields of `href` and `type`
- Links have a required field of `href`

Thus I have added a check for a non-empty `type` as the first check to differentiate Links from Locators.

I've also added a check for `templated` as I commonly see this present in Links but is not permitted in Locators.