### PR TITLE
feat(android, ios, web): emit all book metadata via onPublicationRead…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ allows you to do things like:
 
 - Render an ebook view.
 - Register for location changes (as the user pages through the book).
-- Register for the Table of Contents (so that you can display things like chapters in your app)
+- Access publication metadata including table of contents, positions, and more via the `onPublicationReady` callback
 - Control settings of the Reader. Things like:
   - Dark Mode, Light Mode, Sepia Mode
   - Font Size
@@ -164,6 +164,8 @@ they persist across builds.
 
 ## Usage
 
+### Basic Example
+
 ```tsx
 import React, { useState } from 'react';
 import { ReadiumView } from 'react-native-readium';
@@ -177,6 +179,40 @@ const MyComponent: React.FC = () => {
   return (
     <ReadiumView
       file={file}
+    />
+  );
+}
+```
+
+### Using Publication Metadata
+
+Access the table of contents, positions, and metadata when the publication is ready:
+
+```tsx
+import React, { useState } from 'react';
+import { ReadiumView } from 'react-native-readium';
+import type { File, PublicationReadyEvent } from 'react-native-readium';
+
+const MyComponent: React.FC = () => {
+  const [file] = useState<File>({
+    url: SOME_LOCAL_FILE_URL,
+  });
+
+  const [toc, setToc] = useState([]);
+
+  const handlePublicationReady = (event: PublicationReadyEvent) => {
+    console.log('Title:', event.metadata.title);
+    console.log('Author:', event.metadata.author);
+    console.log('Table of Contents:', event.tableOfContents);
+    console.log('Positions:', event.positions);
+
+    setToc(event.tableOfContents);
+  };
+
+  return (
+    <ReadiumView
+      file={file}
+      onPublicationReady={handlePublicationReady}
     />
   );
 }
@@ -212,7 +248,7 @@ DRM is not supported at this time. However, there is a clear path to [support it
 | `preferences` | [`Partial<Preferences>`](https://github.com/readium/swift-toolkit/blob/main/docs/Guides/Navigator%20Preferences.md#appendix-preference-constraints)  | :white_check_mark: | An object that allows you to control various aspects of the reader's UI (epub only) |
 | `style`    | `ViewStyle`          | :white_check_mark: | A traditional style object. |
 | `onLocationChange` | `(locator: Locator) => void` | :white_check_mark: | A callback that fires whenever the location is changed (e.g. the user transitions to a new page)|
-| `onTableOfContents` | `(toc: Link[] \| null) => void` | :white_check_mark: | A callback that fires once the file is parsed and emits the table of contents embedded in the file. Returns `null` or an empty `[]` if no TOC exists. See the [`Link`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/Link.ts) interface for more info. |
+| `onPublicationReady` | `(event: PublicationReadyEvent) => void` | :white_check_mark: | A callback that fires once the publication is loaded and provides access to the table of contents, positions, and metadata. See the [`PublicationReadyEvent`](https://github.com/5-stones/react-native-readium/blob/main/src/interfaces/PublicationReady.ts) interface for details. |
 
 #### :warning: Web vs Native File URLs
 

--- a/android/src/main/java/com/reactnativereadium/ReadiumView.kt
+++ b/android/src/main/java/com/reactnativereadium/ReadiumView.kt
@@ -16,6 +16,7 @@ import com.reactnativereadium.reader.VisualReaderFragment
 import com.reactnativereadium.utils.Dimensions
 import com.reactnativereadium.utils.File
 import com.reactnativereadium.utils.LinkOrLocator
+import com.reactnativereadium.utils.MetadataNormalizer
 import com.reactnativereadium.utils.toWritableArray
 import com.reactnativereadium.utils.toWritableMap
 import org.readium.r2.navigator.epub.EpubNavigatorFragment
@@ -94,14 +95,18 @@ class ReadiumView(
           val payload = event.locator.toWritableMap()
           dispatch(ReadiumViewManager.ON_LOCATION_CHANGE, payload)
         }
-        is ReaderViewModel.Event.TableOfContentsLoaded -> {
+        is ReaderViewModel.Event.PublicationReady -> {
           val payload = Arguments.createMap().apply {
-            putArray("toc", event.toc.toWritableArray())
+            putArray("tableOfContents", event.tableOfContents.toWritableArray())
+            putArray("positions", event.positions.map { it.toWritableMap() }.let { list ->
+              Arguments.createArray().apply {
+                list.forEach { pushMap(it) }
+              }
+            })
+            // Use spec-based normalizer to ensure consistent structure
+            putMap("metadata", MetadataNormalizer.normalize(event.metadata))
           }
-          dispatch(ReadiumViewManager.ON_TABLE_OF_CONTENTS, payload)
-        }
-        else -> {
-          // do nothing
+          dispatch(ReadiumViewManager.ON_PUBLICATION_READY, payload)
         }
       }
     }

--- a/android/src/main/java/com/reactnativereadium/ReadiumViewManager.kt
+++ b/android/src/main/java/com/reactnativereadium/ReadiumViewManager.kt
@@ -36,10 +36,10 @@ class ReadiumViewManager(
         )
       )
       .put(
-        ON_TABLE_OF_CONTENTS,
+        ON_PUBLICATION_READY,
         MapBuilder.of(
           "phasedRegistrationNames",
-          MapBuilder.of("bubbled", ON_TABLE_OF_CONTENTS)
+          MapBuilder.of("bubbled", ON_PUBLICATION_READY)
         )
       )
       .build()
@@ -145,6 +145,6 @@ class ReadiumViewManager(
   companion object {
     private const val TAG = "ReadiumViewManager"
     var ON_LOCATION_CHANGE = "onLocationChange"
-    var ON_TABLE_OF_CONTENTS = "onTableOfContents"
+    var ON_PUBLICATION_READY = "onPublicationReady"
   }
 }

--- a/android/src/main/java/com/reactnativereadium/reader/ReaderViewModel.kt
+++ b/android/src/main/java/com/reactnativereadium/reader/ReaderViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.channels.Channel
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Metadata
 
 class ReaderViewModel(
   val publication: Publication,
@@ -33,6 +34,10 @@ class ReaderViewModel(
 
     sealed class Event {
         class LocatorUpdate(val locator: Locator) : Event()
-        class TableOfContentsLoaded(val toc: List<Link>) : Event()
+        class PublicationReady(
+            val tableOfContents: List<Link>,
+            val positions: List<Locator>,
+            val metadata: Metadata
+        ) : Event()
     }
 }

--- a/android/src/main/java/com/reactnativereadium/utils/MetadataNormalizer.kt
+++ b/android/src/main/java/com/reactnativereadium/utils/MetadataNormalizer.kt
@@ -1,0 +1,183 @@
+package com.reactnativereadium.utils
+
+import com.facebook.react.bridge.*
+import org.readium.r2.shared.publication.Metadata
+import org.readium.r2.shared.publication.LocalizedString
+import org.readium.r2.shared.publication.Contributor
+import org.readium.r2.shared.publication.Subject
+
+/**
+ * Normalizes metadata to ensure consistent structure per RWPM spec.
+ *
+ * This normalizer works directly with Readium's native Kotlin types (Metadata, LocalizedString,
+ * Contributor, Subject) and converts them to normalized, spec-compliant structures.
+ *
+ * This approach is:
+ * - More efficient (no intermediate WritableMap conversion)
+ * - More type-safe (working with actual Kotlin types)
+ * - Based on the stable RWPM specification
+ *
+ * https://readium.org/webpub-manifest/
+ */
+object MetadataNormalizer {
+
+    /**
+     * Normalizes a Metadata object to a consistent React Native-compatible format.
+     * Works directly with Readium native types for efficiency and type safety.
+     */
+    fun normalize(metadata: Metadata): WritableMap {
+        // Build typed NormalizedMetadata object from Readium's native types
+        val normalized = NormalizedMetadata(
+            // Required fields (provide default empty string if null)
+            title = normalizeLocalizedString(metadata.localizedTitle) ?: "",
+
+            // Optional localized string fields
+            sortAs = normalizeLocalizedString(metadata.localizedSortAs),
+            subtitle = normalizeLocalizedString(metadata.localizedSubtitle),
+
+            // Simple string fields
+            identifier = metadata.identifier,
+            description = metadata.description,
+            readingProgression = metadata.readingProgression?.name?.lowercase(),
+
+            // Date fields (convert Instant to ISO string)
+            modified = metadata.modified?.toString(),
+            published = metadata.published?.toString(),
+
+            // Layout is not directly on Metadata - would need Publication.metadata.presentation
+            // For now, pass null and extract from JSON if needed
+            layout = null,
+
+            // Array fields
+            language = if (metadata.languages.isNotEmpty()) metadata.languages else null,
+            conformsTo = metadata.conformsTo.map { it.uri }.takeIf { it.isNotEmpty() },
+
+            // Numeric fields
+            duration = metadata.duration,
+            numberOfPages = metadata.numberOfPages,
+
+            // Normalize contributors (all types)
+            author = normalizeContributors(metadata.authors),
+            translator = normalizeContributors(metadata.translators),
+            editor = normalizeContributors(metadata.editors),
+            artist = normalizeContributors(metadata.artists),
+            illustrator = normalizeContributors(metadata.illustrators),
+            letterer = normalizeContributors(metadata.letterers),
+            penciler = normalizeContributors(metadata.pencilers),
+            colorist = normalizeContributors(metadata.colorists),
+            inker = normalizeContributors(metadata.inkers),
+            narrator = normalizeContributors(metadata.narrators),
+            contributor = normalizeContributors(metadata.contributors),
+            publisher = normalizeContributors(metadata.publishers),
+            imprint = normalizeContributors(metadata.imprints),
+
+            // Normalize subjects
+            subject = normalizeSubjects(metadata.subjects),
+
+            // Complex objects - these need special handling
+            // For now, convert via JSON if they exist
+            accessibility = metadata.accessibility?.let { convertAccessibilityToWritableMap(it) },
+            belongsTo = if (metadata.belongsTo.isNotEmpty()) convertBelongsToToWritableMap(metadata.belongsTo) else null
+        )
+
+        // Convert to WritableMap for React Native
+        return normalized.toWritableMap()
+    }
+
+    /**
+     * Normalizes a LocalizedString per RWPM spec.
+     *
+     * Per RWPM spec, we extract a single string from the localized string using priority:
+     * 1. null key (undefined/undetermined language)
+     * 2. "en" (English fallback)
+     * 3. First available translation
+     *
+     * https://readium.org/webpub-manifest/contexts/default/
+     */
+    private fun normalizeLocalizedString(value: LocalizedString?): String? {
+        if (value == null) return null
+
+        // Priority: null key (undefined) -> "en" -> first available
+        return value.translations[null]?.string
+            ?: value.translations["en"]?.string
+            ?: value.translations.values.firstOrNull()?.string
+    }
+
+    /**
+     * Normalizes contributors per RWPM spec.
+     *
+     * Converts Readium's Contributor objects to our normalized format.
+     * https://readium.org/webpub-manifest/schema/contributor-object.schema.json
+     */
+    private fun normalizeContributors(contributors: List<Contributor>): List<NormalizedContributor>? {
+        if (contributors.isEmpty()) return null
+
+        return contributors.mapNotNull { contributor ->
+            val name = normalizeLocalizedString(contributor.localizedName) ?: return@mapNotNull null
+
+            NormalizedContributor(
+                name = name,
+                sortAs = normalizeLocalizedString(contributor.localizedSortAs),
+                identifier = contributor.identifier,
+                role = contributor.roles.firstOrNull(),
+                position = contributor.position?.toInt()
+            )
+        }.takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Normalizes subjects per RWPM spec.
+     *
+     * Converts Readium's Subject objects to our normalized format.
+     * https://readium.org/webpub-manifest/schema/subject.schema.json
+     */
+    private fun normalizeSubjects(subjects: List<Subject>): List<NormalizedSubject>? {
+        if (subjects.isEmpty()) return null
+
+        return subjects.mapNotNull { subject ->
+            val name = normalizeLocalizedString(subject.localizedName) ?: return@mapNotNull null
+
+            NormalizedSubject(
+                name = name,
+                sortAs = normalizeLocalizedString(subject.localizedSortAs),
+                code = subject.code,
+                scheme = subject.scheme
+            )
+        }.takeIf { it.isNotEmpty() }
+    }
+
+    /**
+     * Converts Readium's Accessibility object to WritableMap.
+     * This is a complex nested structure that we pass through as-is.
+     */
+    private fun convertAccessibilityToWritableMap(accessibility: org.readium.r2.shared.publication.Accessibility): WritableMap? {
+        return try {
+            // Use Readium's built-in JSON serialization
+            val json = accessibility.toJSON()
+            json.toWritableMap()
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Converts Readium's belongsTo map to WritableMap.
+     * This is a complex nested structure that we pass through as-is.
+     */
+    private fun convertBelongsToToWritableMap(belongsTo: Map<String, List<org.readium.r2.shared.publication.Collection>>): WritableMap? {
+        return try {
+            Arguments.createMap().apply {
+                belongsTo.forEach { (key, collections) ->
+                    val array = Arguments.createArray().apply {
+                        collections.forEach { collection ->
+                            collection.toJSON().toWritableMap()?.let { pushMap(it) }
+                        }
+                    }
+                    putArray(key, array)
+                }
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/android/src/main/java/com/reactnativereadium/utils/NormalizedMetadata.kt
+++ b/android/src/main/java/com/reactnativereadium/utils/NormalizedMetadata.kt
@@ -1,0 +1,179 @@
+package com.reactnativereadium.utils
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+
+/**
+ * Normalized metadata data classes that mirror the TypeScript PublicationMetadata interface.
+ * These provide type safety and structure enforcement during metadata normalization.
+ */
+
+/**
+ * Contributor information for publication metadata
+ */
+data class NormalizedContributor(
+    val name: String,
+    val sortAs: String? = null,
+    val identifier: String? = null,
+    val role: String? = null,
+    val position: Int? = null
+) {
+    fun toWritableMap(): WritableMap {
+        return Arguments.createMap().apply {
+            putString("name", name)
+            sortAs?.let { putString("sortAs", it) }
+            identifier?.let { putString("identifier", it) }
+            role?.let { putString("role", it) }
+            position?.let { putInt("position", it) }
+        }
+    }
+}
+
+/**
+ * Subject/tag information
+ */
+data class NormalizedSubject(
+    val name: String,
+    val sortAs: String? = null,
+    val code: String? = null,
+    val scheme: String? = null
+) {
+    fun toWritableMap(): WritableMap {
+        return Arguments.createMap().apply {
+            putString("name", name)
+            sortAs?.let { putString("sortAs", it) }
+            code?.let { putString("code", it) }
+            scheme?.let { putString("scheme", it) }
+        }
+    }
+}
+
+/**
+ * Normalized publication metadata following the RWPM spec
+ * @see https://readium.org/webpub-manifest/
+ */
+data class NormalizedMetadata(
+    // Required fields
+    val title: String,
+
+    // Optional localized string fields
+    val sortAs: String? = null,
+    val subtitle: String? = null,
+
+    // Simple fields
+    val identifier: String? = null,
+    val description: String? = null,
+    val readingProgression: String? = null,
+    val layout: String? = null,
+    val modified: String? = null,
+    val published: String? = null,
+
+    // Array fields
+    val language: List<String>? = null,
+    val conformsTo: List<String>? = null,
+
+    // Numeric fields
+    val duration: Double? = null,
+    val numberOfPages: Int? = null,
+
+    // Contributors (all types)
+    val author: List<NormalizedContributor>? = null,
+    val translator: List<NormalizedContributor>? = null,
+    val editor: List<NormalizedContributor>? = null,
+    val artist: List<NormalizedContributor>? = null,
+    val illustrator: List<NormalizedContributor>? = null,
+    val letterer: List<NormalizedContributor>? = null,
+    val penciler: List<NormalizedContributor>? = null,
+    val colorist: List<NormalizedContributor>? = null,
+    val inker: List<NormalizedContributor>? = null,
+    val narrator: List<NormalizedContributor>? = null,
+    val contributor: List<NormalizedContributor>? = null,
+    val publisher: List<NormalizedContributor>? = null,
+    val imprint: List<NormalizedContributor>? = null,
+
+    // Subjects
+    val subject: List<NormalizedSubject>? = null,
+
+    // Complex objects (preserved as-is from source)
+    val accessibility: WritableMap? = null,
+    val belongsTo: WritableMap? = null
+) {
+    /**
+     * Converts this normalized metadata to a WritableMap for React Native
+     */
+    fun toWritableMap(): WritableMap {
+        return Arguments.createMap().apply {
+            // Required fields
+            putString("title", title)
+
+            // Optional localized fields
+            sortAs?.let { putString("sortAs", it) }
+            subtitle?.let { putString("subtitle", it) }
+
+            // Simple fields
+            identifier?.let { putString("identifier", it) }
+            description?.let { putString("description", it) }
+            readingProgression?.let { putString("readingProgression", it) }
+            layout?.let { putString("layout", it) }
+            modified?.let { putString("modified", it) }
+            published?.let { putString("published", it) }
+
+            // Array fields
+            language?.let {
+                putArray("language", Arguments.createArray().apply {
+                    it.forEach { lang -> pushString(lang) }
+                })
+            }
+            conformsTo?.let {
+                putArray("conformsTo", Arguments.createArray().apply {
+                    it.forEach { item -> pushString(item) }
+                })
+            }
+
+            // Numeric fields
+            duration?.let { putDouble("duration", it) }
+            numberOfPages?.let { putInt("numberOfPages", it) }
+
+            // Contributors
+            author?.let { putArray("author", it.toContributorWritableArray()) }
+            translator?.let { putArray("translator", it.toContributorWritableArray()) }
+            editor?.let { putArray("editor", it.toContributorWritableArray()) }
+            artist?.let { putArray("artist", it.toContributorWritableArray()) }
+            illustrator?.let { putArray("illustrator", it.toContributorWritableArray()) }
+            letterer?.let { putArray("letterer", it.toContributorWritableArray()) }
+            penciler?.let { putArray("penciler", it.toContributorWritableArray()) }
+            colorist?.let { putArray("colorist", it.toContributorWritableArray()) }
+            inker?.let { putArray("inker", it.toContributorWritableArray()) }
+            narrator?.let { putArray("narrator", it.toContributorWritableArray()) }
+            contributor?.let { putArray("contributor", it.toContributorWritableArray()) }
+            publisher?.let { putArray("publisher", it.toContributorWritableArray()) }
+            imprint?.let { putArray("imprint", it.toContributorWritableArray()) }
+
+            // Subjects
+            subject?.let { putArray("subject", it.toSubjectWritableArray()) }
+
+            // Complex objects
+            accessibility?.let { putMap("accessibility", it) }
+            belongsTo?.let { putMap("belongsTo", it) }
+        }
+    }
+}
+
+/**
+ * Extension function to convert a list of contributors to WritableArray
+ */
+private fun List<NormalizedContributor>.toContributorWritableArray(): WritableArray {
+    return Arguments.createArray().apply {
+        this@toContributorWritableArray.forEach { pushMap(it.toWritableMap()) }
+    }
+}
+
+/**
+ * Extension function to convert a list of subjects to WritableArray
+ */
+private fun List<NormalizedSubject>.toSubjectWritableArray(): WritableArray {
+    return Arguments.createArray().apply {
+        this@toSubjectWritableArray.forEach { pushMap(it.toWritableMap()) }
+    }
+}

--- a/apps/common-app/src/components/Reader.tsx
+++ b/apps/common-app/src/components/Reader.tsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { StyleSheet, View, Text, Platform, DimensionValue } from 'react-native';
 import { ReadiumView } from 'react-native-readium';
-import type { Link, Locator, File, ReadiumProps } from 'react-native-readium';
+import type {
+  Link,
+  Locator,
+  File,
+  ReadiumProps,
+  PublicationReadyEvent,
+} from 'react-native-readium';
 
 import RNFS from '../utils/RNFS';
 import { ReaderButton } from './ReaderButton';
@@ -109,10 +115,10 @@ export const Reader: React.FC<ReaderProps> = ({
               location={location}
               preferences={preferences}
               onLocationChange={(locator: Locator) => setLocation(locator)}
-              onTableOfContents={(toc: Link[] | null) => {
-                if (toc) {
-                  setToc(toc);
-                }
+              onPublicationReady={(event: PublicationReadyEvent) => {
+                console.log('onPublicationReady', event);
+                // Set the TOC from the new event
+                setToc(event.tableOfContents);
               }}
             />
           </View>

--- a/ios/ReadiumView.swift
+++ b/ios/ReadiumView.swift
@@ -34,7 +34,7 @@ class ReadiumView : UIView, Loggable {
     }
   }
   @objc var onLocationChange: RCTDirectEventBlock?
-  @objc var onTableOfContents: RCTDirectEventBlock?
+  @objc var onPublicationReady: RCTDirectEventBlock?
 
   func loadBook(
     url: String,
@@ -162,15 +162,41 @@ class ReadiumView : UIView, Loggable {
     Task { @MainActor [weak self] in
       guard let self = self else { return }
 
+      // Always fetch table of contents and positions, regardless of callback existence
+      // This matches Android behavior and ensures data is loaded consistently
       let tocResult = await vc.publication.tableOfContents()
+      let positionsResult = await vc.publication.positions()
+
+      var payload: [String: Any] = [:]
+
+      // Add table of contents
       switch tocResult {
       case .success(let links):
-        self.onTableOfContents?([
-          "toc": links.map { $0.json }
-        ])
+        payload["tableOfContents"] = links.map { $0.json }
       case .failure(let error):
         self.log(.error, "Failed to fetch table of contents: \(error)")
+        payload["tableOfContents"] = []
       }
+
+      // Add positions
+      switch positionsResult {
+      case .success(let positions):
+        payload["positions"] = positions.map { $0.json }
+      case .failure(let error):
+        self.log(.error, "Failed to fetch positions: \(error)")
+        payload["positions"] = []
+      }
+
+      // Add metadata
+      // Note: Swift Readium library's .json property already normalizes LocalizedStrings
+      // to plain strings, so no additional normalization is needed here.
+      // This matches the RWPM spec's shorthand format and is consistent with our
+      // normalization on Android and Web platforms.
+      payload["metadata"] = vc.publication.metadata.json
+
+      // Always emit onPublicationReady event
+      // React Native bridge handles null callbacks gracefully
+      self.onPublicationReady?(payload)
     }
   }
 }

--- a/ios/ReadiumViewManager.m
+++ b/ios/ReadiumViewManager.m
@@ -6,6 +6,6 @@ RCT_EXPORT_VIEW_PROPERTY(file, NSDictionary *)
 RCT_EXPORT_VIEW_PROPERTY(location, NSDictionary *)
 RCT_EXPORT_VIEW_PROPERTY(preferences, NSString *)
 RCT_EXPORT_VIEW_PROPERTY(onLocationChange, RCTDirectEventBlock)
-RCT_EXPORT_VIEW_PROPERTY(onTableOfContents, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPublicationReady, RCTDirectEventBlock)
 
 @end

--- a/src/ReadiumViewNativeComponent.ts
+++ b/src/ReadiumViewNativeComponent.ts
@@ -5,21 +5,19 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 // eslint-disable-next-line @react-native/no-deep-imports
 import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
 import type { File } from './interfaces/File';
-import type { Link } from './interfaces/Link';
 import type { Locator } from './interfaces/Locator';
+import type { PublicationReadyEvent } from './interfaces/PublicationReady';
 
 // Event types for native events
 type OnLocationChangeEvent = Readonly<Locator>;
-type OnTableOfContentsEvent = Readonly<{
-  toc: ReadonlyArray<Link> | null;
-}>;
+type OnPublicationReadyEvent = Readonly<PublicationReadyEvent>;
 
 // Native component props interface
 export interface NativeProps extends ViewProps {
   file: File;
   preferences?: string;
   onLocationChange?: DirectEventHandler<OnLocationChangeEvent>;
-  onTableOfContents?: DirectEventHandler<OnTableOfContentsEvent>;
+  onPublicationReady?: DirectEventHandler<OnPublicationReadyEvent>;
 }
 
 // Native commands interface

--- a/src/components/ReadiumView.tsx
+++ b/src/components/ReadiumView.tsx
@@ -25,7 +25,7 @@ export const ReadiumView: React.FC<ReadiumProps> = forwardRef(
   (
     {
       onLocationChange: wrappedOnLocationChange,
-      onTableOfContents: wrappedOnTableOfContents,
+      onPublicationReady: wrappedOnPublicationReady,
       preferences,
       ...props
     },
@@ -62,14 +62,13 @@ export const ReadiumView: React.FC<ReadiumProps> = forwardRef(
       [wrappedOnLocationChange]
     );
 
-    const onTableOfContents = useCallback(
+    const onPublicationReady = useCallback(
       (event: any) => {
-        if (wrappedOnTableOfContents) {
-          const toc = event.nativeEvent.toc || null;
-          wrappedOnTableOfContents(toc);
+        if (wrappedOnPublicationReady) {
+          wrappedOnPublicationReady(event.nativeEvent);
         }
       },
-      [wrappedOnTableOfContents]
+      [wrappedOnPublicationReady]
     );
 
     // create the view fragment on android
@@ -102,7 +101,7 @@ export const ReadiumView: React.FC<ReadiumProps> = forwardRef(
           {...props}
           preferences={stringifiedPreferences}
           onLocationChange={onLocationChange}
-          onTableOfContents={onTableOfContents}
+          onPublicationReady={onPublicationReady}
           ref={defaultRef}
         />
       </View>

--- a/src/components/ReadiumView.web.tsx
+++ b/src/components/ReadiumView.web.tsx
@@ -26,7 +26,7 @@ export const ReadiumView = React.forwardRef<
       preferences,
       location,
       onLocationChange,
-      onTableOfContents,
+      onPublicationReady,
       style = {},
       height,
       width,
@@ -37,7 +37,7 @@ export const ReadiumView = React.forwardRef<
     const navigator = useNavigator({
       file,
       onLocationChange,
-      onTableOfContents,
+      onPublicationReady,
       container,
     });
 

--- a/src/interfaces/BaseReadiumViewProps.ts
+++ b/src/interfaces/BaseReadiumViewProps.ts
@@ -2,6 +2,7 @@ import type { ViewStyle } from 'react-native';
 import type { Link } from './Link';
 import type { Locator } from './Locator';
 import type { File } from './File';
+import type { PublicationReadyEvent } from './PublicationReady';
 
 export type BaseReadiumViewProps = {
   file: File;
@@ -9,7 +10,7 @@ export type BaseReadiumViewProps = {
   preferences?: string; // JSON between native and JS, which we deserialise later
   style?: ViewStyle;
   onLocationChange?: (locator: Locator) => void;
-  onTableOfContents?: (toc: Link[] | null) => void;
+  onPublicationReady?: (event: PublicationReadyEvent) => void;
   ref?: any;
   height?: number;
   width?: number;

--- a/src/interfaces/PublicationMetadata.ts
+++ b/src/interfaces/PublicationMetadata.ts
@@ -1,0 +1,141 @@
+/**
+ * Contributor information for publication metadata
+ */
+export interface Contributor {
+  name: string;
+  sortAs?: string;
+  identifier?: string;
+  role?: string;
+  position?: number;
+}
+
+/**
+ * Subject/tag information
+ */
+export interface Subject {
+  name: string;
+  sortAs?: string;
+  code?: string;
+  scheme?: string;
+}
+
+/**
+ * Collection membership information
+ */
+export interface BelongsTo {
+  series?: Array<{ name: string; position?: number }>;
+  collection?: Array<{ name: string; position?: number }>;
+}
+
+/**
+ * Accessibility metadata
+ */
+export interface Accessibility {
+  conformsTo?: string[];
+  certification?: {
+    certifiedBy?: string;
+    credential?: string;
+    report?: string;
+  };
+  accessMode?: string[];
+  accessModeSufficient?: string[];
+  feature?: string[];
+  hazard?: string[];
+  summary?: string;
+}
+
+/**
+ * Publication metadata following Readium Web Publication Manifest spec
+ * @see https://readium.org/webpub-manifest/
+ */
+export interface PublicationMetadata {
+  /** Title of the publication (required) */
+  title: string;
+
+  /** Type of publication (e.g., "http://schema.org/Book") */
+  '@type'?: string;
+
+  /** Profile(s) this publication conforms to */
+  conformsTo?: string | string[];
+
+  /** Sorting key for the title */
+  sortAs?: string;
+
+  /** Subtitle */
+  subtitle?: string;
+
+  /** Unique identifier (URI format) */
+  identifier?: string;
+
+  /** Accessibility metadata */
+  accessibility?: Accessibility;
+
+  /** Last modification date */
+  modified?: string;
+
+  /** Publication date */
+  published?: string;
+
+  /** Language(s) of the publication (BCP 47 tags) */
+  language?: string | string[];
+
+  /** Authors */
+  author?: Contributor[];
+
+  /** Translators */
+  translator?: Contributor[];
+
+  /** Editors */
+  editor?: Contributor[];
+
+  /** Artists */
+  artist?: Contributor[];
+
+  /** Illustrators */
+  illustrator?: Contributor[];
+
+  /** Letterers */
+  letterer?: Contributor[];
+
+  /** Pencilers */
+  penciler?: Contributor[];
+
+  /** Colorists */
+  colorist?: Contributor[];
+
+  /** Inkers */
+  inker?: Contributor[];
+
+  /** Narrators */
+  narrator?: Contributor[];
+
+  /** Other contributors */
+  contributor?: Contributor[];
+
+  /** Publishers */
+  publisher?: Contributor[];
+
+  /** Imprints */
+  imprint?: Contributor[];
+
+  /** Subjects/tags */
+  subject?: Subject[];
+
+  /** Layout type */
+  layout?: 'fixed' | 'reflowable' | 'scrolled';
+
+  /** Reading direction */
+  readingProgression?: 'rtl' | 'ltr';
+
+  /** Description */
+  description?: string;
+
+  /** Duration in seconds (for audiobooks) */
+  duration?: number;
+
+  /** Number of pages */
+  numberOfPages?: number;
+
+  /** Collection membership */
+  belongsTo?: BelongsTo;
+}

--- a/src/interfaces/PublicationReady.ts
+++ b/src/interfaces/PublicationReady.ts
@@ -1,0 +1,18 @@
+import type { Link } from './Link';
+import type { Locator } from './Locator';
+import type { PublicationMetadata } from './PublicationMetadata';
+
+/**
+ * Event payload for onPublicationReady callback
+ * Emitted when the publication has been loaded and all metadata is available
+ */
+export interface PublicationReadyEvent {
+  /** Table of contents */
+  tableOfContents: Link[];
+
+  /** List of positions in the publication */
+  positions: Locator[];
+
+  /** Publication metadata */
+  metadata: PublicationMetadata;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -4,3 +4,5 @@ export * from './File';
 export * from './Link';
 export * from './Locator';
 export * from './Preferences';
+export * from './PublicationMetadata';
+export * from './PublicationReady';

--- a/web/utils/metadataNormalizer.ts
+++ b/web/utils/metadataNormalizer.ts
@@ -1,0 +1,212 @@
+/**
+ * Normalizes metadata to ensure consistent structure per RWPM spec.
+ *
+ * This normalizer is library-agnostic and based on the stable RWPM specification,
+ * ensuring it works regardless of how the underlying Readium library serializes data.
+ *
+ * https://readium.org/webpub-manifest/
+ */
+
+/**
+ * Normalizes a localized string per RWPM spec.
+ *
+ * Per RWPM spec, a localized string can be:
+ * 1. Plain string: "Moby-Dick"
+ * 2. Language map: {"en": "Moby-Dick", "fr": "Moby Dick"}
+ *
+ * Priority for language selection:
+ * 1. "undefined" or "und" (default/undetermined language)
+ * 2. "en" (English fallback)
+ * 3. First available language
+ *
+ * https://readium.org/webpub-manifest/contexts/default/
+ */
+export function normalizeLocalizedString(value: any): string {
+  if (!value) return '';
+
+  // Format 1: Plain string (spec-compliant shorthand)
+  if (typeof value === 'string') return value;
+
+  // Format 2: Language map (spec-compliant full form)
+  if (typeof value === 'object') {
+    // Check if it's a LocalizedString instance with translations property
+    if (value.translations) {
+      const translations = value.translations;
+      return translations['undefined'] ||
+             translations['und'] ||
+             translations['en'] ||
+             Object.values(translations)[0] as string || '';
+    }
+
+    // Check if it's already a plain language map object
+    return value['undefined'] ||
+           value['und'] ||
+           value['en'] ||
+           Object.values(value)[0] as string || '';
+  }
+
+  return '';
+}
+
+/**
+ * Normalizes contributors per RWPM spec.
+ *
+ * Per RWPM spec, a contributor can be:
+ * 1. Plain string: "Herman Melville"
+ * 2. Object: {"name": "Herman Melville", "sortAs": "Melville, Herman"}
+ *
+ * The Web library uses a Contributors class with an "items" property.
+ *
+ * https://readium.org/webpub-manifest/schema/contributor-object.schema.json
+ */
+export function normalizeContributors(value: any): any[] | undefined {
+  if (!value) return undefined;
+
+  // Handle TypeScript library's Contributors class format (has .items property)
+  const items = value.items || value;
+
+  if (!Array.isArray(items)) return undefined;
+
+  return items.map((contributor: any) => {
+    // Format 1: Plain string
+    if (typeof contributor === 'string') {
+      return { name: contributor };
+    }
+
+    // Format 2: Object with potentially localized fields
+    const normalized: any = {
+      name: normalizeLocalizedString(contributor.name),
+    };
+
+    if (contributor.sortAs) {
+      normalized.sortAs = normalizeLocalizedString(contributor.sortAs);
+    }
+    if (contributor.identifier) {
+      normalized.identifier = contributor.identifier;
+    }
+    if (contributor.role) {
+      normalized.role = contributor.role;
+    }
+    if (contributor.position !== undefined) {
+      normalized.position = contributor.position;
+    }
+
+    return normalized;
+  }).filter(c => c.name); // Remove contributors without names
+}
+
+/**
+ * Normalizes subjects per RWPM spec.
+ *
+ * Subject names can be LocalizedStrings.
+ * The Web library uses a Subjects class with an "items" property.
+ *
+ * https://readium.org/webpub-manifest/schema/subject.schema.json
+ */
+export function normalizeSubjects(value: any): any[] | undefined {
+  if (!value) return undefined;
+
+  // Handle Subjects class format (has .items property)
+  const items = value.items || value;
+
+  if (!Array.isArray(items)) return undefined;
+
+  return items.map((subject: any) => {
+    // Format 1: Plain string
+    if (typeof subject === 'string') {
+      return { name: subject };
+    }
+
+    // Format 2: Object
+    const normalized: any = {
+      name: normalizeLocalizedString(subject.name),
+    };
+
+    if (subject.sortAs) {
+      normalized.sortAs = normalizeLocalizedString(subject.sortAs);
+    }
+    if (subject.code) {
+      normalized.code = subject.code;
+    }
+    if (subject.scheme) {
+      normalized.scheme = subject.scheme;
+    }
+
+    return normalized;
+  }).filter(s => s.name);
+}
+
+/**
+ * Normalizes the entire metadata object per RWPM spec.
+ *
+ * This function is library-agnostic and based on the stable RWPM specification,
+ * ensuring it works regardless of how the underlying Readium library serializes data.
+ *
+ * https://readium.org/webpub-manifest/
+ */
+export function normalizeMetadata(metadata: any): any {
+  const normalized: any = {
+    // Title is required
+    title: normalizeLocalizedString(metadata.title),
+  };
+
+  // Optional localized string fields
+  if (metadata.subtitle) {
+    normalized.subtitle = normalizeLocalizedString(metadata.subtitle);
+  }
+  if (metadata.sortAs) {
+    normalized.sortAs = normalizeLocalizedString(metadata.sortAs);
+  }
+
+  // Direct copy fields
+  if (metadata.identifier) normalized.identifier = metadata.identifier;
+  if (metadata.conformsTo) normalized.conformsTo = metadata.conformsTo;
+  if (metadata.description) normalized.description = metadata.description;
+  if (metadata.readingProgression) normalized.readingProgression = metadata.readingProgression;
+  if (metadata.layout) normalized.layout = metadata.layout;
+  if (metadata.duration) normalized.duration = metadata.duration;
+  if (metadata.numberOfPages) normalized.numberOfPages = metadata.numberOfPages;
+
+  // Date fields - convert to ISO strings
+  if (metadata.modified) {
+    normalized.modified = metadata.modified instanceof Date
+      ? metadata.modified.toISOString()
+      : metadata.modified;
+  }
+  if (metadata.published) {
+    normalized.published = metadata.published instanceof Date
+      ? metadata.published.toISOString()
+      : metadata.published;
+  }
+
+  // Languages (Web uses plural 'languages', our interface uses singular 'language')
+  if (metadata.languages) {
+    normalized.language = metadata.languages;
+  }
+
+  // Normalize all contributor types (Web uses plural names, our interface uses singular)
+  if (metadata.authors) normalized.author = normalizeContributors(metadata.authors);
+  if (metadata.translators) normalized.translator = normalizeContributors(metadata.translators);
+  if (metadata.editors) normalized.editor = normalizeContributors(metadata.editors);
+  if (metadata.artists) normalized.artist = normalizeContributors(metadata.artists);
+  if (metadata.illustrators) normalized.illustrator = normalizeContributors(metadata.illustrators);
+  if (metadata.letterers) normalized.letterer = normalizeContributors(metadata.letterers);
+  if (metadata.pencilers) normalized.penciler = normalizeContributors(metadata.pencilers);
+  if (metadata.colorists) normalized.colorist = normalizeContributors(metadata.colorists);
+  if (metadata.inkers) normalized.inker = normalizeContributors(metadata.inkers);
+  if (metadata.narrators) normalized.narrator = normalizeContributors(metadata.narrators);
+  if (metadata.contributors) normalized.contributor = normalizeContributors(metadata.contributors);
+  if (metadata.publishers) normalized.publisher = normalizeContributors(metadata.publishers);
+  if (metadata.imprints) normalized.imprint = normalizeContributors(metadata.imprints);
+
+  // Normalize subjects
+  if (metadata.subjects) {
+    normalized.subject = normalizeSubjects(metadata.subjects);
+  }
+
+  // Copy complex objects as-is
+  if (metadata.belongsTo) normalized.belongsTo = metadata.belongsTo;
+  if (metadata.accessibility) normalized.accessibility = metadata.accessibility;
+
+  return normalized;
+}


### PR DESCRIPTION
…y callback

remove the onTableOfContents callback in favor of a more complete onPublicationReady callback

BREAKING CHANGE: onTableOfContents has been removed and replaced with onPublicationReady

#67