### PR TITLE
fix: respect React Native architecture filters

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,15 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['Readium_' + name]).toInteger()
 }
 
+def getReactNativeArchitectures() {
+  def value = project.findProperty('reactNativeArchitectures')
+  if (value) {
+    return value.toString().split(',').collect { it.trim() }.findAll { it }
+  }
+
+  return ['x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a']
+}
+
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   namespace "com.reactnativereadium"
@@ -39,7 +48,7 @@ android {
       cmake {
         cppFlags "-O2 -frtti -fexceptions -Wall -fstack-protector-all"
         arguments "-DANDROID_STL=c++_shared", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
-        abiFilters "x86", "x86_64", "armeabi-v7a", "arm64-v8a"
+        abiFilters (*getReactNativeArchitectures())
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": ">=0.78.0",
-    "react-native-nitro-modules": "*"
+    "react-native-nitro-modules": "^0.35.0"
   },
   "jest": {
     "preset": "react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14275,7 +14275,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: ">=0.78.0"
-    react-native-nitro-modules: "*"
+    react-native-nitro-modules: ^0.35.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- Respect `reactNativeArchitectures` when configuring Android ABI filters.
- Keep the current full-ABI default when the property is not set.
- Require `react-native-nitro-modules` `^0.35.0` to match the generated native code.

Related to #117.

## Validation

- `corepack yarn install --immutable`
- `corepack yarn typescript`
- `corepack yarn test --coverage --runInBand`
- `corepack yarn prepare`
- `./gradlew :react-native-readium:assembleDebug --no-daemon --stacktrace --rerun-tasks`
- `./gradlew :react-native-readium:externalNativeBuildDebug -PreactNativeArchitectures=arm64-v8a --no-daemon --stacktrace --rerun-tasks`
- `./gradlew :app:assembleDebug --no-daemon --stacktrace`

`corepack yarn lint` still fails on pre-existing Prettier/inline-style issues outside this change.
